### PR TITLE
Update hotspot-disabler to GNOME 3.2

### DIFF
--- a/Gnome-shell-activities-hotspot-disabler/extension.js
+++ b/Gnome-shell-activities-hotspot-disabler/extension.js
@@ -5,11 +5,20 @@
  * 
  */
 
-const Panel = imports.ui.panel;
+const Panel = imports.ui.layout;
 
 function main() {
 //clear the _onCornerEntered function so there will be no hotspot    
     Panel.HotCorner.prototype._onCornerEntered = function() {
 			return false;
 		};
+}
+
+function init() {
+}
+
+function enable() {
+}
+
+function disable() {
 }

--- a/Gnome-shell-activities-hotspot-disabler/extension.js
+++ b/Gnome-shell-activities-hotspot-disabler/extension.js
@@ -7,18 +7,18 @@
 
 const Panel = imports.ui.layout;
 
-function main() {
-//clear the _onCornerEntered function so there will be no hotspot    
-    Panel.HotCorner.prototype._onCornerEntered = function() {
-			return false;
-		};
-}
-
 function init() {
+    old_function = Panel.HotCorner.prototype._onCornerEntered;
 }
 
 function enable() {
+    //clear the _onCornerEntered function so there will be no hotspot
+    Panel.HotCorner.prototype._onCornerEntered = function() {
+        return false;
+    };
 }
 
 function disable() {
+    //restore the _onCornerEntered function
+    Panel.HotCorner.prototype._onCornerEntered = old_function;
 }

--- a/Gnome-shell-activities-hotspot-disabler/extension.js
+++ b/Gnome-shell-activities-hotspot-disabler/extension.js
@@ -1,24 +1,23 @@
 /*
  * Gnome-Shell Hot corner disabler
  * Author: Herman Boomsma
- * 
+ * Author: Nathaniel Case
  * 
  */
 
+const Main = imports.ui.main;
 const Panel = imports.ui.layout;
 
 function init() {
-    old_function = Panel.HotCorner.prototype._onCornerEntered;
+    Panel.HotCorner.prototype.setReactive = function(enable) {
+        this._corner.reactive = enable;
+    }
 }
 
 function enable() {
-    //clear the _onCornerEntered function so there will be no hotspot
-    Panel.HotCorner.prototype._onCornerEntered = function() {
-        return false;
-    };
+    Main.panel._activitiesButton._hotCorner.setReactive(false);
 }
 
 function disable() {
-    //restore the _onCornerEntered function
-    Panel.HotCorner.prototype._onCornerEntered = old_function;
+    Main.panel._activitiesButton._hotCorner.setReactive(true);
 }

--- a/Gnome-shell-activities-hotspot-disabler/metadata.json
+++ b/Gnome-shell-activities-hotspot-disabler/metadata.json
@@ -1,5 +1,5 @@
 {"shell-version": ["3.2"],
-"uuid": "activitieshotspotdisabler@harmus.gmail.com", 
-"name": "Activities hotspot disabler", 
-"description": "This extension disables the activities hotspot, so the activities screen is only activated by clicking on 'Activities' or pressing the super key (or alt+F1)", 
+"uuid": "activitieshotspotdisabler@harmus.gmail.com",
+"name": "Activities hotspot disabler",
+"description": "This extension disables the activities hotspot, so the activities screen is only activated by clicking on 'Activities' or pressing the super key (or alt+F1)",
 "url": "http://www.hermit.eu"}

--- a/Gnome-shell-activities-hotspot-disabler/metadata.json
+++ b/Gnome-shell-activities-hotspot-disabler/metadata.json
@@ -1,4 +1,4 @@
-{"shell-version": ["3.0.0", "3.0.1", "3.0.2"], 
+{"shell-version": ["3.2"],
 "uuid": "activitieshotspotdisabler@harmus.gmail.com", 
 "name": "Activities hotspot disabler", 
 "description": "This extension disables the activities hotspot, so the activities screen is only activated by clicking on 'Activities' or pressing the super key (or alt+F1)", 


### PR DESCRIPTION
I don't know if you're still looking at this, but I modified the hotspot disabler so it would work again in GNOME 3.2, after much frustration on my end when this wonderful extension stopped working.
