### PR TITLE
Update hotspot disabler to Gnome 3.6

### DIFF
--- a/Gnome-shell-activities-hotspot-disabler/extension.js
+++ b/Gnome-shell-activities-hotspot-disabler/extension.js
@@ -8,16 +8,30 @@
 const Main = imports.ui.main;
 const Panel = imports.ui.layout;
 
+let _monitorChangeId;
+
 function init() {
-    Panel.HotCorner.prototype.setReactive = function(enable) {
-        this._corner.reactive = enable;
-    }
 }
 
 function enable() {
-    Main.panel._activitiesButton._hotCorner.setReactive(false);
+    hotCorners(false);
+    Main.panel._activitiesButton._hotCorner._corner.reactive = false;
+    _monitorChangeId = Main.layoutManager.connect('monitors-changed', disableHotCorners);
 }
 
 function disable() {
-    Main.panel._activitiesButton._hotCorner.setReactive(true);
+    hotCorners(true);
+    Main.panel._activitiesButton._hotCorner._corner.reactive = true;
+    Main.layoutManager.disconnect(_monitorChangeId);
+}
+
+function disableHotCorners() {
+    hotCorners(false);
+}
+
+function hotCorners(enable) {
+    for(let i = 0; i < Main.layoutManager._hotCorners.length; i++) {
+        hotcorner = Main.layoutManager._hotCorners[i];
+        hotcorner._corner.reactive = enable;
+    }
 }

--- a/Gnome-shell-activities-hotspot-disabler/extension.js
+++ b/Gnome-shell-activities-hotspot-disabler/extension.js
@@ -2,11 +2,10 @@
  * Gnome-Shell Hot corner disabler
  * Author: Herman Boomsma
  * Author: Nathaniel Case
- * 
+ *
  */
 
 const Main = imports.ui.main;
-const Panel = imports.ui.layout;
 
 let _monitorChangeId;
 
@@ -15,13 +14,13 @@ function init() {
 
 function enable() {
     hotCorners(false);
-    Main.panel._activitiesButton._hotCorner._corner.reactive = false;
+    Main.panel.statusArea.activities.hotCorner._corner.reactive = false;
     _monitorChangeId = Main.layoutManager.connect('monitors-changed', disableHotCorners);
 }
 
 function disable() {
     hotCorners(true);
-    Main.panel._activitiesButton._hotCorner._corner.reactive = true;
+    Main.panel.statusArea.activities.hotCorner._corner.reactive = true;
     Main.layoutManager.disconnect(_monitorChangeId);
 }
 

--- a/Gnome-shell-activities-hotspot-disabler/metadata.json
+++ b/Gnome-shell-activities-hotspot-disabler/metadata.json
@@ -1,4 +1,4 @@
-{"shell-version": ["3.2", "3.4"],
+{"shell-version": ["3.2", "3.4", "3.6"],
 "uuid": "activitieshotspotdisabler@harmus.gmail.com",
 "name": "Activities hotspot disabler",
 "description": "This extension disables the activities hotspot, so the activities screen is only activated by clicking on 'Activities' or pressing the super key (or alt+F1)",

--- a/Gnome-shell-activities-hotspot-disabler/metadata.json
+++ b/Gnome-shell-activities-hotspot-disabler/metadata.json
@@ -1,4 +1,4 @@
-{"shell-version": ["3.2", "3.4", "3.6"],
+{"shell-version": ["3.6"],
 "uuid": "activitieshotspotdisabler@harmus.gmail.com",
 "name": "Activities hotspot disabler",
 "description": "This extension disables the activities hotspot, so the activities screen is only activated by clicking on 'Activities' or pressing the super key (or alt+F1)",

--- a/Gnome-shell-activities-hotspot-disabler/metadata.json
+++ b/Gnome-shell-activities-hotspot-disabler/metadata.json
@@ -1,4 +1,4 @@
-{"shell-version": ["3.2"],
+{"shell-version": ["3.2", "3.4"],
 "uuid": "activitieshotspotdisabler@harmus.gmail.com",
 "name": "Activities hotspot disabler",
 "description": "This extension disables the activities hotspot, so the activities screen is only activated by clicking on 'Activities' or pressing the super key (or alt+F1)",


### PR DESCRIPTION
I don't know if you keep up with this at all, but here's an update to the latest version of Gnome-shell.
